### PR TITLE
Use default Prettier configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "trailingComma": "all",
-  "semi": false,
-  "singleQuote": true
-}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,8 @@
-import type { InitialOptionsTsJest } from 'ts-jest'
+import type { InitialOptionsTsJest } from "ts-jest";
 
 const config: InitialOptionsTsJest = {
-  testEnvironment: 'jsdom',
-  preset: 'ts-jest',
+  testEnvironment: "jsdom",
+  preset: "ts-jest",
   coverageThreshold: {
     global: {
       branches: 100,
@@ -11,6 +11,6 @@ const config: InitialOptionsTsJest = {
       statements: 100,
     },
   },
-}
+};
 
-export default config
+export default config;

--- a/src/usePromise.test.ts
+++ b/src/usePromise.test.ts
@@ -1,130 +1,130 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { describe, it, expect } from '@jest/globals'
-import usePromise, { isFulfilled, isPending, isRejected } from './usePromise'
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect } from "@jest/globals";
+import usePromise, { isFulfilled, isPending, isRejected } from "./usePromise";
 
 // This promise never resolves or rejects, making it useful for testing the pending state.
-const UNSETTLED_PROMISE = new Promise(() => {})
+const UNSETTLED_PROMISE = new Promise(() => {});
 
-describe('isPending', () => {
-  it('checks if a result is pending', () => {
-    expect(isPending({ status: 'pending' })).toBe(true)
-  })
-})
+describe("isPending", () => {
+  it("checks if a result is pending", () => {
+    expect(isPending({ status: "pending" })).toBe(true);
+  });
+});
 
-describe('isFulfilled', () => {
-  it('checks if a result is fulfilled', () => {
-    expect(isFulfilled({ status: 'fulfilled', value: null })).toBe(true)
-  })
-})
+describe("isFulfilled", () => {
+  it("checks if a result is fulfilled", () => {
+    expect(isFulfilled({ status: "fulfilled", value: null })).toBe(true);
+  });
+});
 
-describe('isRejected', () => {
-  it('checks if a result is rejected', () => {
-    expect(isRejected({ status: 'rejected', reason: null })).toBe(true)
-  })
-})
+describe("isRejected", () => {
+  it("checks if a result is rejected", () => {
+    expect(isRejected({ status: "rejected", reason: null })).toBe(true);
+  });
+});
 
-describe('usePromise', () => {
-  it('returns a pending result', () => {
-    const { result } = renderHook(() => usePromise(() => UNSETTLED_PROMISE))
+describe("usePromise", () => {
+  it("returns a pending result", () => {
+    const { result } = renderHook(() => usePromise(() => UNSETTLED_PROMISE));
 
-    expect(result.current).toEqual({ status: 'pending' })
-  })
+    expect(result.current).toEqual({ status: "pending" });
+  });
 
-  it('returns a fulfilled result', async () => {
-    const value = 'foo'
+  it("returns a fulfilled result", async () => {
+    const value = "foo";
     const { result } = renderHook(() =>
-      usePromise(() => Promise.resolve(value)),
-    )
+      usePromise(() => Promise.resolve(value))
+    );
 
     await waitFor(() => {
-      expect(result.current).toEqual({ status: 'fulfilled', value })
-    })
-  })
+      expect(result.current).toEqual({ status: "fulfilled", value });
+    });
+  });
 
-  it('returns a rejected result', async () => {
-    const reason = new Error('Whoopsie')
+  it("returns a rejected result", async () => {
+    const reason = new Error("Whoopsie");
     const { result } = renderHook(() =>
-      usePromise(() => Promise.reject(reason)),
-    )
+      usePromise(() => Promise.reject(reason))
+    );
 
     await waitFor(() => {
-      expect(result.current).toEqual({ status: 'rejected', reason })
-    })
-  })
+      expect(result.current).toEqual({ status: "rejected", reason });
+    });
+  });
 
-  it('updates the result when dependencies change', async () => {
-    let currentCount = 0
-    let retryCount = 0
+  it("updates the result when dependencies change", async () => {
+    let currentCount = 0;
+    let retryCount = 0;
 
     async function nextNumber() {
       // eslint-disable-next-line no-plusplus
-      return Promise.resolve(currentCount++)
+      return Promise.resolve(currentCount++);
     }
 
     const { result, rerender } = renderHook(() =>
-      usePromise(() => nextNumber(), [retryCount]),
-    )
+      usePromise(() => nextNumber(), [retryCount])
+    );
 
     await waitFor(() => {
-      expect(result.current).toEqual({ status: 'fulfilled', value: 0 })
-    })
+      expect(result.current).toEqual({ status: "fulfilled", value: 0 });
+    });
 
-    retryCount = 1
-    rerender()
+    retryCount = 1;
+    rerender();
 
     await waitFor(() => {
-      expect(result.current).toEqual({ status: 'fulfilled', value: 1 })
-    })
-  })
+      expect(result.current).toEqual({ status: "fulfilled", value: 1 });
+    });
+  });
 
-  it('aborts when unmounted before the promise was settled', () => {
-    let currentSignal: AbortSignal
+  it("aborts when unmounted before the promise was settled", () => {
+    let currentSignal: AbortSignal;
     const { unmount } = renderHook(() =>
       usePromise((signal) => {
-        currentSignal = signal
-        return UNSETTLED_PROMISE
-      }, []),
-    )
+        currentSignal = signal;
+        return UNSETTLED_PROMISE;
+      }, [])
+    );
 
-    unmount()
+    unmount();
 
     // @ts-ignore
-    expect(currentSignal.aborted).toBe(true)
-  })
+    expect(currentSignal.aborted).toBe(true);
+  });
 
-  it('aborts when dependencies change before the promise was settled', () => {
-    let isCancelled = false
-    let currentSignal: AbortSignal
+  it("aborts when dependencies change before the promise was settled", () => {
+    let isCancelled = false;
+    let currentSignal: AbortSignal;
     const { rerender } = renderHook(() =>
       usePromise(
         (signal) => {
           if (!isCancelled) {
-            currentSignal = signal
+            currentSignal = signal;
           }
 
-          return UNSETTLED_PROMISE
+          return UNSETTLED_PROMISE;
         },
-        [isCancelled],
-      ),
-    )
+        [isCancelled]
+      )
+    );
 
-    isCancelled = true
-    rerender()
+    isCancelled = true;
+    rerender();
 
     // @ts-ignore
-    expect(currentSignal.aborted).toBe(true)
-  })
+    expect(currentSignal.aborted).toBe(true);
+  });
 
-  it('prevents setting the result when aborted before the promise was settled', async () => {
+  it("prevents setting the result when aborted before the promise was settled", async () => {
     const promise = new Promise<void>((resolve) => {
-      setTimeout(resolve)
-    })
-    const { result, unmount } = renderHook(() => usePromise(() => promise))
+      setTimeout(resolve);
+    });
+    const { result, unmount } = renderHook(() => usePromise(() => promise));
 
-    unmount()
-    await act(() => promise)
+    unmount();
+    await act(() => promise);
 
-    expect(result.current).toEqual({ status: 'pending' })
-  })
-})
+    expect(result.current).toEqual({ status: "pending" });
+  });
+});

--- a/src/usePromise.ts
+++ b/src/usePromise.ts
@@ -1,40 +1,40 @@
-import type { DependencyList } from 'react'
-import { useEffect, useState } from 'react'
+import type { DependencyList } from "react";
+import { useEffect, useState } from "react";
 
-export type PromiseResult<T> = PromisePendingResult | PromiseSettledResult<T>
+export type PromiseResult<T> = PromisePendingResult | PromiseSettledResult<T>;
 
 export interface PromisePendingResult {
-  status: 'pending'
+  status: "pending";
 }
 
 /**
  * Function that creates a promise, takes a signal to abort fetch requests.
  */
-export type PromiseFactoryFn<T> = (signal: AbortSignal) => Promise<T>
+export type PromiseFactoryFn<T> = (signal: AbortSignal) => Promise<T>;
 
 /**
  * Determines if the result of a promise is pending.
  * @param result Result to check.
  */
 export const isPending = <T>(
-  result: PromiseResult<T>,
-): result is PromisePendingResult => result.status === 'pending'
+  result: PromiseResult<T>
+): result is PromisePendingResult => result.status === "pending";
 
 /**
  * Determines if the result of a promise is fulfilled.
  * @param result Result to check.
  */
 export const isFulfilled = <T>(
-  result: PromiseResult<T>,
-): result is PromiseFulfilledResult<T> => result.status === 'fulfilled'
+  result: PromiseResult<T>
+): result is PromiseFulfilledResult<T> => result.status === "fulfilled";
 
 /**
  * Determines if the result of a promise is rejected.
  * @param result Result to check.
  */
 export const isRejected = <T>(
-  result: PromiseResult<T>,
-): result is PromiseRejectedResult => result.status === 'rejected'
+  result: PromiseResult<T>
+): result is PromiseRejectedResult => result.status === "rejected";
 
 /**
  * Takes a function that creates a Promise and returns its pending, fulfilled, or rejected result.
@@ -60,31 +60,31 @@ export const isRejected = <T>(
  */
 export default function usePromise<T>(
   factory: PromiseFactoryFn<T>,
-  deps: DependencyList = [],
+  deps: DependencyList = []
 ): PromiseResult<T> {
-  const [result, setResult] = useState<PromiseResult<T>>({ status: 'pending' })
+  const [result, setResult] = useState<PromiseResult<T>>({ status: "pending" });
 
   useEffect(() => {
     if (!isPending(result)) {
-      setResult({ status: 'pending' })
+      setResult({ status: "pending" });
     }
 
-    const controller = new AbortController()
-    const { signal } = controller
+    const controller = new AbortController();
+    const { signal } = controller;
 
     async function handlePromise() {
-      const [promiseResult] = await Promise.allSettled([factory(signal)])
+      const [promiseResult] = await Promise.allSettled([factory(signal)]);
 
       if (!signal.aborted) {
-        setResult(promiseResult)
+        setResult(promiseResult);
       }
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    handlePromise()
+    handlePromise();
 
-    return () => controller.abort()
-  }, deps)
+    return () => controller.abort();
+  }, deps);
 
-  return result
+  return result;
 }


### PR DESCRIPTION
Removes overrides for the Prettier configuration, opting to use the defaults instead.